### PR TITLE
searchBFFにeslintを導入した

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,8 +7,8 @@
   ],
   "eslint.packageManager": "yarn",
   "eslint.workingDirectories": [
-    { "directory": "./packages/app", "changeProcessCWD": true },
-    { "directory": "./packages/bff", "changeProcessCWD": true },
+    { "directory": "./packages/searchApp", "changeProcessCWD": true },
+    { "directory": "./packages/searchBFF", "changeProcessCWD": true },
     { "directory": "./packages/hasura", "changeProcessCWD": true }
   ],
   "editor.codeActionsOnSave": {

--- a/packages/searchBFF/.eslintrc.js
+++ b/packages/searchBFF/.eslintrc.js
@@ -1,0 +1,104 @@
+module.exports = {
+  env: {
+    es2021: true,
+    node: true,
+  },
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    sourceType: "module",
+    ecmaVersion: 12,
+    project: ["./tsconfig.json"],
+    tsconfigRootDir: __dirname,
+  },
+  plugins: ["@typescript-eslint", "import", "unused-imports"],
+  extends: [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:@typescript-eslint/recommended-requiring-type-checking",
+    "plugin:import/recommended",
+    "plugin:import/typescript",
+    "prettier",
+  ],
+  ignorePatterns: [".eslintrc.js", "*.config.js", "codegen.js", "setupTest.js"],
+  rules: {
+    // eslint
+    "no-unused-vars": "off", // @typescript-eslint/no-unused-varsを有効化するため、オフにする。
+
+    // typescript-eslint
+    "@typescript-eslint/no-unused-vars": ["warn", { argsIgnorePattern: "^_" }],
+    "@typescript-eslint/no-unsafe-assignment": "off",
+    "@typescript-eslint/no-unsafe-member-access": "off",
+    "@typescript-eslint/no-floating-promises": "off",
+    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-misused-promises": [
+      "error",
+      {
+        checksVoidReturn: false,
+      },
+    ],
+    "@typescript-eslint/naming-convention": [
+      "error",
+      {
+        selector: "typeAlias",
+        format: ["PascalCase"],
+      },
+    ],
+    "@typescript-eslint/unbound-method": "off",
+    "@typescript-eslint/naming-convention": [
+      "error",
+      {
+        selector: "typeAlias",
+        format: ["PascalCase"],
+      },
+    ],
+
+    // unused-imports
+    "unused-imports/no-unused-imports-ts": "warn",
+
+    // import
+    "import/namespace": "off",
+    "import/order": [
+      "error",
+      {
+        pathGroups: [
+          {
+            pattern: "~/**",
+            group: "external",
+            position: "after",
+          },
+        ],
+        groups: [
+          "builtin",
+          "external",
+          "internal",
+          "unknown",
+          "parent",
+          "sibling",
+          "index",
+          "object",
+          "type",
+        ],
+      },
+    ],
+    "no-restricted-imports": [
+      "error",
+      {
+        patterns: [
+          {
+            group: ["./", "../"],
+          },
+        ],
+      },
+    ],
+  },
+  settings: {
+    "import/resolver": {
+      node: {
+        extensions: [".js", ".ts"],
+      },
+      typescript: {
+        project: "./tsconfig.json",
+      },
+    },
+  },
+};

--- a/packages/searchBFF/.eslintrc.js
+++ b/packages/searchBFF/.eslintrc.js
@@ -3,101 +3,101 @@ module.exports = {
     es2021: true,
     node: true,
   },
-  parser: "@typescript-eslint/parser",
+  parser: '@typescript-eslint/parser',
   parserOptions: {
-    sourceType: "module",
+    sourceType: 'module',
     ecmaVersion: 12,
-    project: ["./tsconfig.json"],
+    project: ['./tsconfig.json'],
     tsconfigRootDir: __dirname,
   },
-  plugins: ["@typescript-eslint", "import", "unused-imports"],
+  plugins: ['@typescript-eslint', 'import', 'unused-imports'],
   extends: [
-    "eslint:recommended",
-    "plugin:@typescript-eslint/recommended",
-    "plugin:@typescript-eslint/recommended-requiring-type-checking",
-    "plugin:import/recommended",
-    "plugin:import/typescript",
-    "prettier",
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:@typescript-eslint/recommended-requiring-type-checking',
+    'plugin:import/recommended',
+    'plugin:import/typescript',
+    'prettier',
   ],
-  ignorePatterns: [".eslintrc.js", "*.config.js", "codegen.js", "setupTest.js"],
+  ignorePatterns: ['.eslintrc.js', '*.config.js', 'codegen.js', 'setupTest.js'],
   rules: {
     // eslint
-    "no-unused-vars": "off", // @typescript-eslint/no-unused-varsを有効化するため、オフにする。
+    'no-unused-vars': 'off', // @typescript-eslint/no-unused-varsを有効化するため、オフにする。
 
     // typescript-eslint
-    "@typescript-eslint/no-unused-vars": ["warn", { argsIgnorePattern: "^_" }],
-    "@typescript-eslint/no-unsafe-assignment": "off",
-    "@typescript-eslint/no-unsafe-member-access": "off",
-    "@typescript-eslint/no-floating-promises": "off",
-    "@typescript-eslint/no-explicit-any": "off",
-    "@typescript-eslint/no-misused-promises": [
-      "error",
+    '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+    '@typescript-eslint/no-unsafe-assignment': 'off',
+    '@typescript-eslint/no-unsafe-member-access': 'off',
+    '@typescript-eslint/no-floating-promises': 'off',
+    '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-misused-promises': [
+      'error',
       {
         checksVoidReturn: false,
       },
     ],
-    "@typescript-eslint/naming-convention": [
-      "error",
+    '@typescript-eslint/naming-convention': [
+      'error',
       {
-        selector: "typeAlias",
-        format: ["PascalCase"],
+        selector: 'typeAlias',
+        format: ['PascalCase'],
       },
     ],
-    "@typescript-eslint/unbound-method": "off",
-    "@typescript-eslint/naming-convention": [
-      "error",
+    '@typescript-eslint/unbound-method': 'off',
+    '@typescript-eslint/naming-convention': [
+      'error',
       {
-        selector: "typeAlias",
-        format: ["PascalCase"],
+        selector: 'typeAlias',
+        format: ['PascalCase'],
       },
     ],
 
     // unused-imports
-    "unused-imports/no-unused-imports-ts": "warn",
+    'unused-imports/no-unused-imports-ts': 'warn',
 
     // import
-    "import/namespace": "off",
-    "import/order": [
-      "error",
+    'import/namespace': 'off',
+    'import/order': [
+      'error',
       {
         pathGroups: [
           {
-            pattern: "~/**",
-            group: "external",
-            position: "after",
+            pattern: '~/**',
+            group: 'external',
+            position: 'after',
           },
         ],
         groups: [
-          "builtin",
-          "external",
-          "internal",
-          "unknown",
-          "parent",
-          "sibling",
-          "index",
-          "object",
-          "type",
+          'builtin',
+          'external',
+          'internal',
+          'unknown',
+          'parent',
+          'sibling',
+          'index',
+          'object',
+          'type',
         ],
       },
     ],
-    "no-restricted-imports": [
-      "error",
+    'no-restricted-imports': [
+      'error',
       {
         patterns: [
           {
-            group: ["./", "../"],
+            group: ['./', '../'],
           },
         ],
       },
     ],
   },
   settings: {
-    "import/resolver": {
+    'import/resolver': {
       node: {
-        extensions: [".js", ".ts"],
+        extensions: ['.js', '.ts'],
       },
       typescript: {
-        project: "./tsconfig.json",
+        project: './tsconfig.json',
       },
     },
   },

--- a/packages/searchBFF/.eslintrc.js
+++ b/packages/searchBFF/.eslintrc.js
@@ -36,13 +36,6 @@ module.exports = {
         checksVoidReturn: false,
       },
     ],
-    '@typescript-eslint/naming-convention': [
-      'error',
-      {
-        selector: 'typeAlias',
-        format: ['PascalCase'],
-      },
-    ],
     '@typescript-eslint/unbound-method': 'off',
     '@typescript-eslint/naming-convention': [
       'error',

--- a/packages/searchBFF/package.json
+++ b/packages/searchBFF/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "NODE_ENV=local webpack --watch --progress"
+    "start": "NODE_ENV=local webpack --watch --progress",
+    "lint": "eslint ."
   },
   "keywords": [],
   "author": "",
@@ -12,7 +13,14 @@
   "devDependencies": {
     "@types/express": "^4.17.14",
     "@types/node": "^18.11.10",
+    "@typescript-eslint/eslint-plugin": "^5.45.1",
+    "@typescript-eslint/parser": "^5.45.1",
     "case-sensitive-paths-webpack-plugin": "^2.4.0",
+    "eslint": "^8.29.0",
+    "eslint-config-prettier": "^8.5.0",
+    "eslint-import-resolver-typescript": "^3.5.2",
+    "eslint-plugin-import": "^2.26.0",
+    "eslint-plugin-unused-imports": "^2.0.0",
     "nodemon-webpack-plugin": "^4.8.1",
     "ts-loader": "^9.4.2",
     "typescript": "^4.9.3",

--- a/packages/searchBFF/package.json
+++ b/packages/searchBFF/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "NODE_ENV=local webpack --watch --progress",
-    "lint": "eslint ."
+    "lint": "eslint --ext .ts ."
   },
   "keywords": [],
   "author": "",

--- a/packages/searchBFF/src/index.ts
+++ b/packages/searchBFF/src/index.ts
@@ -1,7 +1,7 @@
 import { ApolloServer } from "apollo-server-express";
 import express from "express";
 import { ApolloServerPluginLandingPageLocalDefault } from "apollo-server-core";
-import { schema } from "./schema";
+import { schema } from "~/schema";
 
 const port = process.env.PORT || 1111;
 

--- a/packages/searchBFF/src/index.ts
+++ b/packages/searchBFF/src/index.ts
@@ -1,7 +1,7 @@
-import { ApolloServer } from "apollo-server-express";
-import express from "express";
-import { ApolloServerPluginLandingPageLocalDefault } from "apollo-server-core";
-import { schema } from "~/schema";
+import { ApolloServer } from 'apollo-server-express';
+import express from 'express';
+import { ApolloServerPluginLandingPageLocalDefault } from 'apollo-server-core';
+import { schema } from '~/schema';
 
 const port = process.env.PORT || 1111;
 
@@ -18,10 +18,10 @@ const main = async () => {
   await server.start();
   server.applyMiddleware({
     app,
-    path: "/graphql",
+    path: '/graphql',
   });
 
-  app.listen({ port, host: "0.0.0.0" }, () => {
+  app.listen({ port, host: '0.0.0.0' }, () => {
     console.log(`🙆‍♂️ http://localhost:${port}/graphql`);
   });
 };

--- a/packages/searchBFF/tsconfig.json
+++ b/packages/searchBFF/tsconfig.json
@@ -8,7 +8,6 @@
     "esModuleInterop": true,
     "outDir": "dist",
     "resolveJsonModule": true,
-    "noErrorTruncation": true,
     "baseUrl": ".",
     "paths": {
       "~/*": ["src/*"]

--- a/packages/searchBFF/tsconfig.json
+++ b/packages/searchBFF/tsconfig.json
@@ -8,6 +8,7 @@
     "esModuleInterop": true,
     "outDir": "dist",
     "resolveJsonModule": true,
+    "noErrorTruncation": true,
     "baseUrl": ".",
     "paths": {
       "~/*": ["src/*"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -793,6 +793,21 @@
     semver "^7.3.7"
     tsutils "^3.21.0"
 
+"@typescript-eslint/eslint-plugin@^5.45.1":
+  version "5.45.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.45.1.tgz#ee5b51405f6c9ee7e60e4006d68c69450d3b4536"
+  integrity sha512-cOizjPlKEh0bXdFrBLTrI/J6B/QMlhwE9auOov53tgB+qMukH6/h8YAK/qw+QJGct/PTbdh2lytGyipxCcEtAw==
+  dependencies:
+    "@typescript-eslint/scope-manager" "5.45.1"
+    "@typescript-eslint/type-utils" "5.45.1"
+    "@typescript-eslint/utils" "5.45.1"
+    debug "^4.3.4"
+    ignore "^5.2.0"
+    natural-compare-lite "^1.4.0"
+    regexpp "^3.2.0"
+    semver "^7.3.7"
+    tsutils "^3.21.0"
+
 "@typescript-eslint/parser@^5.45.0":
   version "5.45.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.45.0.tgz#b18a5f6b3cf1c2b3e399e9d2df4be40d6b0ddd0e"
@@ -803,6 +818,16 @@
     "@typescript-eslint/typescript-estree" "5.45.0"
     debug "^4.3.4"
 
+"@typescript-eslint/parser@^5.45.1":
+  version "5.45.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.45.1.tgz#6440ec283fa1373a12652d4e2fef4cb6e7b7e8c6"
+  integrity sha512-JQ3Ep8bEOXu16q0ztsatp/iQfDCtvap7sp/DKo7DWltUquj5AfCOpX2zSzJ8YkAVnrQNqQ5R62PBz2UtrfmCkA==
+  dependencies:
+    "@typescript-eslint/scope-manager" "5.45.1"
+    "@typescript-eslint/types" "5.45.1"
+    "@typescript-eslint/typescript-estree" "5.45.1"
+    debug "^4.3.4"
+
 "@typescript-eslint/scope-manager@5.45.0":
   version "5.45.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.45.0.tgz#7a4ac1bfa9544bff3f620ab85947945938319a96"
@@ -810,6 +835,14 @@
   dependencies:
     "@typescript-eslint/types" "5.45.0"
     "@typescript-eslint/visitor-keys" "5.45.0"
+
+"@typescript-eslint/scope-manager@5.45.1":
+  version "5.45.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.45.1.tgz#5b87d025eec7035d879b99c260f03be5c247883c"
+  integrity sha512-D6fCileR6Iai7E35Eb4Kp+k0iW7F1wxXYrOhX/3dywsOJpJAQ20Fwgcf+P/TDtvQ7zcsWsrJaglaQWDhOMsspQ==
+  dependencies:
+    "@typescript-eslint/types" "5.45.1"
+    "@typescript-eslint/visitor-keys" "5.45.1"
 
 "@typescript-eslint/type-utils@5.45.0":
   version "5.45.0"
@@ -821,10 +854,25 @@
     debug "^4.3.4"
     tsutils "^3.21.0"
 
+"@typescript-eslint/type-utils@5.45.1":
+  version "5.45.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.45.1.tgz#cb7d300c3c95802cea9f87c7f8be363cf8f8538c"
+  integrity sha512-aosxFa+0CoYgYEl3aptLe1svP910DJq68nwEJzyQcrtRhC4BN0tJAvZGAe+D0tzjJmFXe+h4leSsiZhwBa2vrA==
+  dependencies:
+    "@typescript-eslint/typescript-estree" "5.45.1"
+    "@typescript-eslint/utils" "5.45.1"
+    debug "^4.3.4"
+    tsutils "^3.21.0"
+
 "@typescript-eslint/types@5.45.0":
   version "5.45.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.45.0.tgz#794760b9037ee4154c09549ef5a96599621109c5"
   integrity sha512-QQij+u/vgskA66azc9dCmx+rev79PzX8uDHpsqSjEFtfF2gBUTRCpvYMh2gw2ghkJabNkPlSUCimsyBEQZd1DA==
+
+"@typescript-eslint/types@5.45.1":
+  version "5.45.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.45.1.tgz#8e1883041cee23f1bb7e1343b0139f97f6a17c14"
+  integrity sha512-HEW3U0E5dLjUT+nk7b4lLbOherS1U4ap+b9pfu2oGsW3oPu7genRaY9dDv3nMczC1rbnRY2W/D7SN05wYoGImg==
 
 "@typescript-eslint/typescript-estree@5.45.0":
   version "5.45.0"
@@ -833,6 +881,19 @@
   dependencies:
     "@typescript-eslint/types" "5.45.0"
     "@typescript-eslint/visitor-keys" "5.45.0"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-glob "^4.0.3"
+    semver "^7.3.7"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/typescript-estree@5.45.1":
+  version "5.45.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.45.1.tgz#b3dc37f0c4f0fe73e09917fc735e6f96eabf9ba4"
+  integrity sha512-76NZpmpCzWVrrb0XmYEpbwOz/FENBi+5W7ipVXAsG3OoFrQKJMiaqsBMbvGRyLtPotGqUfcY7Ur8j0dksDJDng==
+  dependencies:
+    "@typescript-eslint/types" "5.45.1"
+    "@typescript-eslint/visitor-keys" "5.45.1"
     debug "^4.3.4"
     globby "^11.1.0"
     is-glob "^4.0.3"
@@ -853,12 +914,34 @@
     eslint-utils "^3.0.0"
     semver "^7.3.7"
 
+"@typescript-eslint/utils@5.45.1":
+  version "5.45.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.45.1.tgz#39610c98bde82c4792f2a858b29b7d0053448be2"
+  integrity sha512-rlbC5VZz68+yjAzQBc4I7KDYVzWG2X/OrqoZrMahYq3u8FFtmQYc+9rovo/7wlJH5kugJ+jQXV5pJMnofGmPRw==
+  dependencies:
+    "@types/json-schema" "^7.0.9"
+    "@types/semver" "^7.3.12"
+    "@typescript-eslint/scope-manager" "5.45.1"
+    "@typescript-eslint/types" "5.45.1"
+    "@typescript-eslint/typescript-estree" "5.45.1"
+    eslint-scope "^5.1.1"
+    eslint-utils "^3.0.0"
+    semver "^7.3.7"
+
 "@typescript-eslint/visitor-keys@5.45.0":
   version "5.45.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.45.0.tgz#e0d160e9e7fdb7f8da697a5b78e7a14a22a70528"
   integrity sha512-jc6Eccbn2RtQPr1s7th6jJWQHBHI6GBVQkCHoJFQ5UreaKm59Vxw+ynQUPPY2u2Amquc+7tmEoC2G52ApsGNNg==
   dependencies:
     "@typescript-eslint/types" "5.45.0"
+    eslint-visitor-keys "^3.3.0"
+
+"@typescript-eslint/visitor-keys@5.45.1":
+  version "5.45.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.45.1.tgz#204428430ad6a830d24c5ac87c71366a1cfe1948"
+  integrity sha512-cy9ln+6rmthYWjH9fmx+5FU/JDpjQb586++x2FZlveq7GdGuLLW9a2Jcst2TGekH82bXpfmRNSwP9tyEs6RjvQ==
+  dependencies:
+    "@typescript-eslint/types" "5.45.1"
     eslint-visitor-keys "^3.3.0"
 
 "@vitejs/plugin-react@^2.2.0":


### PR DESCRIPTION
`searchBFF`に、eslintを導入しました。

- 変数が宣言されているのに使用されていない場合
- Promiseが不適切に使用されている場合
- 型名の頭文字が小文字になっている場合
- 使っていない関数などがimportされている場合
- import文の順序が規則通りになっていない場合
- importが相対パスで行われている場合
以上の場合に警告を出すように設定しました。
