### PR TITLE
入力内容を修正するボタンを作成した

### DIFF
--- a/packages/postApp/package.json
+++ b/packages/postApp/package.json
@@ -17,6 +17,7 @@
     "@emotion/css": "^11.10.5",
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
+    "@mui/icons-material": "^5.11.0",
     "@mui/material": "^5.10.17",
     "graphql": "^16.6.0",
     "react": "^18.2.0",

--- a/packages/postApp/src/components/Button/index.tsx
+++ b/packages/postApp/src/components/Button/index.tsx
@@ -6,6 +6,8 @@ type Props = {
   onClick: (e: MouseEvent<HTMLButtonElement>) => void;
   disabled?: boolean;
   variant?: 'outlined' | 'contained' | 'text';
+  startIcon?: React.ReactNode;
+  endIcon?: React.ReactNode;
 };
 
 export const Button = ({
@@ -13,13 +15,17 @@ export const Button = ({
   onClick,
   disabled = false,
   variant = 'outlined',
+  startIcon,
+  endIcon,
 }: Props) => {
   return (
     <MUIButton
       variant={variant}
       onClick={onClick}
       color="inherit"
-      disabled={disabled}>
+      disabled={disabled}
+      startIcon={startIcon}
+      endIcon={endIcon}>
       {label}
     </MUIButton>
   );

--- a/packages/postApp/src/pages/Top/QuestionConditionView/index.tsx
+++ b/packages/postApp/src/pages/Top/QuestionConditionView/index.tsx
@@ -112,7 +112,7 @@ export const QuestionConditionView: FC<Props> = ({
       <div>ここには注釈が入ります。</div>
       <div>
         <Button
-          label="問題を投稿する"
+          label="入力内容を確認する"
           disabled={!inputValid}
           onClick={onClickConfirmation}
         />

--- a/packages/postApp/src/pages/Top/QuestionConfirmationView/index.tsx
+++ b/packages/postApp/src/pages/Top/QuestionConfirmationView/index.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/css';
 import { FC } from 'react';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import { Button } from '~/components/Button';
 import { Option } from '~/components/Select';
 
@@ -12,6 +13,7 @@ type Props = {
   category: Option<number> | undefined;
   tags: Option<string>[];
   author: string;
+  onClickReturnPageButton: () => void;
   onSubmit: () => void;
 };
 export const QuestionConfirmationView: FC<Props> = ({
@@ -23,6 +25,7 @@ export const QuestionConfirmationView: FC<Props> = ({
   category,
   tags,
   author,
+  onClickReturnPageButton,
   onSubmit,
 }) => {
   return (
@@ -63,8 +66,13 @@ export const QuestionConfirmationView: FC<Props> = ({
         <div className={labelStyle}>作問者・出典</div>
         <div>{author ?? ''}</div>
       </div>
-
-      <div>
+      <div className={buttonsWrapper}>
+        <Button
+          label="入力内容を修正する"
+          onClick={onClickReturnPageButton}
+          variant="text"
+          startIcon={<ArrowBackIcon />}
+        />
         <Button label="問題を投稿する" onClick={onSubmit} />
       </div>
     </div>
@@ -77,4 +85,12 @@ const fieldStyle = css``;
 
 const labelStyle = css`
   font-weight: bold;
+`;
+
+const buttonsWrapper = css`
+  display: flex;
+  flex-direction: column;
+  width: 200px;
+  gap: 20px;
+  margin: 20px 40px;
 `;

--- a/packages/postApp/src/pages/Top/hooks/index.ts
+++ b/packages/postApp/src/pages/Top/hooks/index.ts
@@ -85,6 +85,11 @@ export const useTopPage = () => {
       setIsConfirmation(true);
     }
   };
+
+  const handleClickReturnPageButton = () => {
+    setIsConfirmation(false);
+  };
+
   const [startAddQuestion, { loading: _startAddQuestionLoading }] =
     useAddQuestionMutation();
 
@@ -118,6 +123,7 @@ export const useTopPage = () => {
     inputValid,
     isConfirmation,
     onClickConfirmation,
+    onClickReturnPageButton: handleClickReturnPageButton,
     onSubmit,
     onChangeQuestion: handleChangeQuestion,
     onChangeAnswer: handleChangeAnswer,

--- a/packages/postApp/src/pages/Top/index.tsx
+++ b/packages/postApp/src/pages/Top/index.tsx
@@ -25,6 +25,7 @@ export const Top = () => {
     onChangeTags,
     onChangeAuthor,
     onClickConfirmation,
+    onClickReturnPageButton,
     onSubmit,
   } = useTopPage();
 
@@ -64,6 +65,7 @@ export const Top = () => {
           category={category}
           tags={tags}
           author={author}
+          onClickReturnPageButton={onClickReturnPageButton}
           onSubmit={onSubmit}
         />
       )}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1277,7 +1277,7 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.17.8", "@babel/runtime@^7.18.3", "@babel/runtime@^7.20.1", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.17.8", "@babel/runtime@^7.18.3", "@babel/runtime@^7.20.1", "@babel/runtime@^7.20.6", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
   version "7.20.6"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.20.6.tgz#facf4879bfed9b5326326273a64220f099b0fce3"
   integrity sha512-Q+8MqP7TiHMWzSfwiJwXCjyf4GYA4Dgw3emg/7xmwsdLJOZUp+nMqcOwOzzYheuM1rhDu8FSj2l0aoMygEuXuA==
@@ -2623,6 +2623,13 @@
   version "5.10.17"
   resolved "https://registry.yarnpkg.com/@mui/core-downloads-tracker/-/core-downloads-tracker-5.10.17.tgz#ce105d692b77fcb41e0c060f3aea0c8ca566ff5a"
   integrity sha512-iNwUuMA30nrN0tiEkeD3zaczv7Tk2jlZIDbXRnijAsYXkZtl/xEzQsVRIPYRDuyEz6D18vQJhV8h7gPUXEubTg==
+
+"@mui/icons-material@^5.11.0":
+  version "5.11.0"
+  resolved "https://registry.yarnpkg.com/@mui/icons-material/-/icons-material-5.11.0.tgz#9ea6949278b2266d2683866069cd43009eaf6464"
+  integrity sha512-I2LaOKqO8a0xcLGtIozC9xoXjZAto5G5gh0FYUMAlbsIHNHIjn4Xrw9rvjY20vZonyiGrZNMAlAXYkY6JvhF6A==
+  dependencies:
+    "@babel/runtime" "^7.20.6"
 
 "@mui/material@^5.10.17":
   version "5.10.17"


### PR DESCRIPTION
「入力内容を修正する」ボタンを作成し、入力内容確認画面から入力画面に戻れるようにしました。
また、@mui/icons-materialを導入し、ボタンコンポーネント内にアイコンを表示できるようにしました。
<img width="330" alt="image" src="https://user-images.githubusercontent.com/85165382/208825730-cc7afc64-6db5-4c9f-b82f-1ec1c3e58d8f.png">
