### PR TITLE
フォントサイズとカラーの変更

### DIFF
--- a/packages/postApp/src/pages/Top/QuestionConditionView/index.tsx
+++ b/packages/postApp/src/pages/Top/QuestionConditionView/index.tsx
@@ -109,7 +109,7 @@ export const QuestionConditionView: FC<Props> = ({
         label="作問者・出典"
         control={<TextField value={author} onChange={onChangeAuthor} />}
       />
-      <div>ここには注釈が入ります。</div>
+      <div className={fontStyle}>ここには注釈が入ります。</div>
       <div>
         <Button
           label="入力内容を確認する"
@@ -125,4 +125,8 @@ const wrapper = css`
   display: flex;
   flex-direction: column;
   gap: 1rem;
+`;
+const fontStyle = css`
+  font-size: 12px;
+  color: #585656;
 `;


### PR DESCRIPTION
投稿画面の注釈の箇所にスタイリングを適用し、フォントサイズとカラーの変更を行ないました。
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/108654244/209609738-0450581c-a4cc-4462-b095-a004b7361dc8.png">
