### PR TITLE
検索画面でタグを表示し、タグ間が狭かったためstyleを適用しました。

### DIFF
--- a/packages/searchApp/src/pages/Top/QuizSearchResultList/index.tsx
+++ b/packages/searchApp/src/pages/Top/QuizSearchResultList/index.tsx
@@ -65,7 +65,16 @@ export const QuizSearchResultList = (props: Props) => {
               <TableCell component="th" scope="row">
                 {question?.category ?? ''}
               </TableCell>
-              <TableCell component="th" scope="row"></TableCell>
+              <TableCell component="th" scope="row">
+                {question.tags &&
+                  question?.tags.map((tag) => {
+                    return (
+                      <span key={tag} className={tagStyle}>
+                        {tag}
+                      </span>
+                    );
+                  })}
+              </TableCell>
               <TableCell component="th" scope="row">
                 {question?.question}
               </TableCell>
@@ -88,4 +97,8 @@ export const QuizSearchResultList = (props: Props) => {
 
 const difficultyTableHeadTextStyle = css`
   white-space: nowrap;
+`;
+
+const tagStyle = css`
+  padding: 4px;
 `;


### PR DESCRIPTION
検索画面にタグを表示しました。
タグが複数ある場合も問題なく表示されることを確認しました。
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/108654244/209637369-bc1523e5-9a6c-45ef-ab2d-917ad6569303.png">
