### PR TITLE
クイズ追加内容確認画面で選択したカテゴリが表示されない問題を修正しました

### DIFF
--- a/packages/postApp/src/components/Select/index.tsx
+++ b/packages/postApp/src/components/Select/index.tsx
@@ -23,9 +23,15 @@ export const Select = <T extends string | number>({
   onChange,
 }: Props<T>) => {
   const handleChange = useCallback(
-    (e: SelectChangeEvent<T>) =>
-      onChange({ label: e.target.name, value: e.target.value as T }),
-    [onChange],
+    (e: SelectChangeEvent<T>) => {
+      // 選択されたvalueのlabelを取得
+      const label =
+        options.find(({ value }) => {
+          return value === e.target.value;
+        })?.label ?? '';
+      onChange({ label: label, value: e.target.value as T });
+    },
+    [onChange, options],
   );
 
   return (

--- a/packages/postApp/src/pages/Top/hooks/index.ts
+++ b/packages/postApp/src/pages/Top/hooks/index.ts
@@ -57,7 +57,7 @@ export const useTopPage = () => {
         pronunciation,
         description,
         difficulty: difficulty?.value,
-        category: category?.value,
+        categoryId: category?.value,
         tags: tags.map(({ value }) => value),
         // ToDo user機能が実装されていないので一旦固定値になっているが、ログインユーザーのIDにすべき。
         userId: 'b94838ad-0f2d-44a2-b4d9-1e273b78995a',
@@ -138,13 +138,13 @@ export const useTopPage = () => {
 };
 
 const validationSchema = z.object({
-  question: z.string(),
-  answer: z.string(),
+  question: z.string().min(1),
+  answer: z.string().min(1),
   pronunciation: z.string().optional(),
   description: z.string().optional(),
-  difficulty: z.number().optional(),
+  difficulty: z.number(),
   categoryId: z.number().optional(),
   tags: z.array(z.string()).optional(),
-  userId: z.string(),
+  userId: z.string().uuid(),
   author: z.string().optional(),
 });


### PR DESCRIPTION
クイズ追加内容確認画面で選択したカテゴリが表示されない問題を修正しました。
Selctコンポーネントにて選択したカテゴリのlabelとvalueをstateへ保存しているはずでしたが、MUI Selectコンポーネントには選択したlabelを保存する機能は無かったため、onChange関数内にてlabelも配列から取り出して保存するように変更しました。

また同時にzodによるバリデーションを修正しました。
こちらは、string型に対して最低文字数の指定を行っていなかったため、```""``` であっても文字列であるという条件を満たしてしまっていました。
単純に設定を間違えている部分もあったため、合わせて修正し、仕様の通りのバリデーションになることを確認しました。